### PR TITLE
Update utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -62,7 +62,7 @@ read_until_eof(FILE *stream) {
     size_t n = fread(buf, 1, 1024, stream);
     len += strlen(buf);
     str = realloc(str, len);
-    strcat(str, buf);
+    strncat(str, buf, n);
   }
   
   return str;


### PR DESCRIPTION
use `strncat` instead `strcat`, cause when each time read more than 1024 characters, the `buf` may contains more characters than expected.